### PR TITLE
Add functionality to validate user for remote dashboard creation api.…

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -58,6 +58,10 @@ auth.adRootDn=[dc=your,dc=company,dc=com]
 # This will be your active directory url (required for AD)
 auth.adUrl=[Need an example]
 
+# Needed if you want query ldap
+auth.ldapBindUser=[binduser]
+auth.ldapBindPass=[bindpass]
+
 monitor.proxy.host=[hostname of proxy server]
 monitor.proxy.type=[http|socks|direct]
 monitor.proxy.port=[port enabled on proxy server]

--- a/api/docker/properties-builder.sh
+++ b/api/docker/properties-builder.sh
@@ -64,6 +64,10 @@ auth.adRootDn=${AUTH_AD_ROOT_DN:-}
 # This is your active directory url
 auth.adUrl=${AUTH_AD_URL:-}
 
+# Needed if you want to query ldap
+auth.ldapBindUser=${AUTH_LDAP_BIND_USER:-}
+auth.ldapBindPass=${AUTH_LDAP_BIND_PASS:-}
+
 #Monitor Widget proxy credentials
 monitor.proxy.username=${MONITOR_PROXY_USERNAME:-}
 monitor.proxy.password=${MONITOR_PROXY_PASSWORD:-}

--- a/api/src/main/java/com/capitalone/dashboard/auth/AuthProperties.java
+++ b/api/src/main/java/com/capitalone/dashboard/auth/AuthProperties.java
@@ -31,6 +31,9 @@ public class AuthProperties {
 	private String adDomain;
 	private String adRootDn;
 	private String adUrl;
+
+	private String ldapBindUser;
+	private String ldapBindPass;
 	
 	public void setExpirationTime(Long expirationTime) {
 		this.expirationTime = expirationTime;
@@ -95,6 +98,22 @@ public class AuthProperties {
     public void setAdUrl(String adUrl) {
         this.adUrl = adUrl;
     }
+
+	public String getLdapBindUser() {
+		return ldapBindUser;
+	}
+
+	public void setLdapBindUser(String ldapBindUser) {
+		this.ldapBindUser = ldapBindUser;
+	}
+
+	public String getLdapBindPass() {
+		return ldapBindPass;
+	}
+
+	public void setLdapBindPass(String ldapBindPass) {
+		this.ldapBindPass = ldapBindPass;
+	}
 
 	@PostConstruct
 	public void applyDefaultsIfNeeded() {

--- a/api/src/main/java/com/capitalone/dashboard/service/UserInfoService.java
+++ b/api/src/main/java/com/capitalone/dashboard/service/UserInfoService.java
@@ -14,5 +14,5 @@ public interface UserInfoService {
 	Collection<UserInfo> getUsers();
     UserInfo promoteToAdmin(String username, AuthType authType);
     UserInfo demoteFromAdmin(String username, AuthType authType);
-
+	boolean isUserValid(String userId, AuthType authType);
 }

--- a/api/src/main/java/com/capitalone/dashboard/service/UserInfoServiceImpl.java
+++ b/api/src/main/java/com/capitalone/dashboard/service/UserInfoServiceImpl.java
@@ -2,7 +2,11 @@ package com.capitalone.dashboard.service;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Properties;
 
+import com.capitalone.dashboard.auth.AuthProperties;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -16,10 +20,22 @@ import com.capitalone.dashboard.model.UserRole;
 import com.capitalone.dashboard.repository.UserInfoRepository;
 import com.google.common.collect.Sets;
 
+import javax.naming.Context;
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+import javax.naming.directory.Attribute;
+import javax.naming.directory.InitialDirContext;
+import javax.naming.directory.SearchControls;
+import javax.naming.directory.SearchResult;
+
 @Component
 public class UserInfoServiceImpl implements UserInfoService {
 
+	private static final Logger LOGGER = Logger.getLogger(UserInfoServiceImpl.class);
+
 	private UserInfoRepository userInfoRepository;
+	@Autowired
+	private AuthProperties authProperties;
 	
 	@Autowired
 	public UserInfoServiceImpl(UserInfoRepository userInfoRepository) {
@@ -109,4 +125,82 @@ public class UserInfoServiceImpl implements UserInfoService {
 		return grantedAuthorities;
 	}
 
+	/**
+	 * Can be called to check validity of userId when creating a dashboard remotely via api
+	 * @param userId
+	 * @param authType
+	 * @return
+	 */
+	@Override
+	public boolean isUserValid(String userId, AuthType authType) {
+		if (userInfoRepository.findByUsernameAndAuthType(userId, authType) != null) {
+			return true;
+		} else {
+			if (authType == AuthType.LDAP) {
+				try {
+					return searchLdapUser(userId);
+				} catch (NamingException ne) {
+					LOGGER.error("Failed to query ldap for " + userId, ne);
+					return false;
+				}
+			} else {
+				return false;
+			}
+		}
+	}
+
+	private boolean searchLdapUser(String searchId) throws NamingException {
+		boolean searchResult = false;
+
+		Properties props = new Properties();
+		props.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
+		props.put("java.naming.security.protocol", "ssl");
+		props.put(Context.SECURITY_AUTHENTICATION, "simple");
+
+		if(!StringUtils.isBlank(authProperties.getAdUrl())) {
+			props.put(Context.PROVIDER_URL, authProperties.getAdUrl());
+			props.put(Context.SECURITY_PRINCIPAL, authProperties.getLdapBindUser() + "@" + authProperties.getAdDomain());
+		} else {
+			props.put(Context.PROVIDER_URL, authProperties.getLdapServerUrl());
+			props.put(Context.SECURITY_PRINCIPAL, StringUtils.replace(authProperties.getLdapUserDnPattern(), "{0}", authProperties.getLdapBindUser()));
+		}
+		props.put(Context.SECURITY_CREDENTIALS, authProperties.getLdapBindPass());
+
+		InitialDirContext context = new InitialDirContext(props);
+
+		try {
+			SearchControls ctrls = new SearchControls();
+			ctrls.setSearchScope(SearchControls.SUBTREE_SCOPE);
+
+			String searchBase = "";
+			String searchFilter = "";
+			if(!StringUtils.isBlank(authProperties.getAdUrl())) {
+				searchBase = authProperties.getAdRootDn();
+				searchFilter = "(&(objectClass=user)(userPrincipalName="	+ searchId + "@" + authProperties.getAdDomain() + "))";
+			} else {
+				searchBase = authProperties.getLdapUserDnPattern().substring(
+						authProperties.getLdapUserDnPattern().indexOf(',') + 1,
+						authProperties.getLdapUserDnPattern().length()
+				);
+				searchFilter = "(&(objectClass=user)(sAMAccountName="	+ searchId + "))";
+			}
+
+			NamingEnumeration<SearchResult> results = context.search(searchBase, searchFilter, ctrls);
+
+			if (!results.hasMore()) {
+				return searchResult;
+			}
+
+			SearchResult result = results.next();
+
+			Attribute memberOf = result.getAttributes().get("memberOf");
+			if (memberOf != null) {
+				searchResult = true;
+			}
+		} finally {
+			context.close();
+		}
+
+		return searchResult;
+	}
 }

--- a/api/src/test/java/com/capitalone/dashboard/service/UserInfoServiceImplTest.java
+++ b/api/src/test/java/com/capitalone/dashboard/service/UserInfoServiceImplTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.when;
 import java.util.ArrayList;
 import java.util.Collection;
 
+import com.capitalone.dashboard.auth.AuthProperties;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -35,6 +36,9 @@ public class UserInfoServiceImplTest {
     
     @Mock
     private UserInfoRepository userInfoRepository;
+
+    @Mock
+    private AuthProperties authProperties;
     
     @InjectMocks
     private UserInfoServiceImpl service;
@@ -177,6 +181,21 @@ public class UserInfoServiceImplTest {
         assertFalse(result.getAuthorities().contains(UserRole.ROLE_ADMIN));
         verify(userInfoRepository).save(user);
         
+    }
+
+    @Test
+    public void shouldValidateUser() {
+        UserInfo user = new UserInfo();
+        user.setUsername("standarduser");
+        user.setAuthType(AuthType.STANDARD);
+
+        when(userInfoRepository.findByUsernameAndAuthType("abc123", AuthType.STANDARD)).thenReturn(null);
+        boolean result = service.isUserValid("abc123", AuthType.STANDARD);
+        assertFalse(result);
+
+        when(userInfoRepository.findByUsernameAndAuthType("standarduser", AuthType.STANDARD)).thenReturn(user);
+        result = service.isUserValid("standarduser", AuthType.STANDARD);
+        assertTrue(result);
     }
 
 }


### PR DESCRIPTION
… (#1555)

* Update readme for encryption section.

* Change load order of AWSCredentialsProviderChain.

* Active directory support and administer dashboard owners.

* Active directory support and administer dashboard owners.

* Secure APIs Basic Auth.

* Secure APIs Basic Auth.

* Secure APIs Basic Auth.

* Secure APIs Basic Auth.

* Secure APIs Basic Auth.

* Fix for api losing connectivity with mongo.

* Fix AuthType stacktrace.

* Cleanup files and fix token auth type.

* Fix for github pulls, issues and commits.

* Fix for github pulls, issues and commits.

* Fix for null authType.

* Add functionality to validate user for remote dashboard creation api.