### PR TITLE
Add support for Jira feature widget to display boards as teams. (#1644)

### DIFF
--- a/collectors/feature/jira/src/main/java/com/capitalone/dashboard/client/JiraClient.java
+++ b/collectors/feature/jira/src/main/java/com/capitalone/dashboard/client/JiraClient.java
@@ -11,6 +11,8 @@ public interface JiraClient {
 	List<Issue> getIssues(long startTime, int pageStart);
 	
 	List<BasicProject> getProjects();
+
+	List<Team> getBoards(int startAt, List<Team> result);
 	
 	List<Team> getTeams();
 	

--- a/collectors/feature/jira/src/main/java/com/capitalone/dashboard/client/story/StoryDataClientImpl.java
+++ b/collectors/feature/jira/src/main/java/com/capitalone/dashboard/client/story/StoryDataClientImpl.java
@@ -38,6 +38,8 @@ import com.capitalone.dashboard.util.FeatureSettings;
 import org.apache.commons.lang.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.bson.types.ObjectId;
+import org.codehaus.jettison.json.JSONException;
+import org.codehaus.jettison.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -353,9 +355,23 @@ public class StoryDataClientImpl implements StoryDataClient {
 
 		IssueField team = fields.get(featureSettings.getJiraTeamFieldName());
 		if (team != null && team.getValue() != null && !TOOLS.sanitizeResponse(team.getValue()).isEmpty()) {
-			String teamID = TOOLS.sanitizeResponse(team.getValue());
+			Object teamObj = team.getValue();
 
-			Team scopeOwner = teamRepository.findByTeamId(teamID);
+			String teamID = "";
+			Team scopeOwner = null;
+			if (teamObj instanceof JSONObject) {
+				try {
+					String teamName = (String)((JSONObject)teamObj).get("value");
+					scopeOwner = teamRepository.findByName(teamName);
+					teamID = scopeOwner.getTeamId();
+				} catch (JSONException e) {
+					LOGGER.error("Unable to parse value for " + teamObj);
+				}
+			} else {
+				teamID = TOOLS.sanitizeResponse(team.getValue());
+				scopeOwner = teamRepository.findByTeamId(teamID);
+			}
+
 			// sTeamID
 			feature.setsTeamID(teamID);
 			if (scopeOwner != null && StringUtils.isNotEmpty(scopeOwner.getName())) {

--- a/collectors/feature/jira/src/main/java/com/capitalone/dashboard/client/team/TeamDataClientImpl.java
+++ b/collectors/feature/jira/src/main/java/com/capitalone/dashboard/client/team/TeamDataClientImpl.java
@@ -7,10 +7,12 @@ import com.capitalone.dashboard.repository.TeamRepository;
 import com.capitalone.dashboard.util.FeatureCollectorConstants;
 import com.capitalone.dashboard.util.FeatureSettings;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
 import org.bson.types.ObjectId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -53,8 +55,14 @@ public class TeamDataClientImpl implements TeamDataClient {
 	 */
 	public int updateTeamInformation() {
 		int count = 0;
-		
-		List<Team> teams = jiraClient.getTeams();
+
+		List<Team> teams = null;
+		String jiraBoardAsTeam = featureSettings.getJiraBoardAsTeam();
+		if (!StringUtils.isEmpty(jiraBoardAsTeam) && Boolean.parseBoolean(jiraBoardAsTeam)) {
+			teams = jiraClient.getBoards(0, new ArrayList<Team>());
+		} else {
+			teams = jiraClient.getTeams();
+		}
 		
 		if (CollectionUtils.isNotEmpty(teams)) {
 			updateMongoInfo(teams);
@@ -94,6 +102,9 @@ public class TeamDataClientImpl implements TeamDataClient {
 
 			// name
 			team.setName(jiraTeam.getName());
+
+			// teamType
+			team.setTeamType(jiraTeam.getTeamType());
 
 			// changeDate - does not exist for jira
 			team.setChangeDate("");

--- a/collectors/feature/jira/src/main/java/com/capitalone/dashboard/util/FeatureSettings.java
+++ b/collectors/feature/jira/src/main/java/com/capitalone/dashboard/util/FeatureSettings.java
@@ -91,6 +91,8 @@ public class FeatureSettings {
 	
 	private String jiraTeamFieldName;
 
+	private String jiraBoardAsTeam;
+
 	public String getCron() {
 		return this.cron;
 	}
@@ -329,5 +331,13 @@ public class FeatureSettings {
 
 	public void setJiraTeamFieldName(String jiraTeamFieldName) {
 		this.jiraTeamFieldName = jiraTeamFieldName;
+	}
+
+	public String getJiraBoardAsTeam() {
+		return jiraBoardAsTeam;
+	}
+
+	public void setJiraBoardAsTeam(String jiraBoardAsTeam) {
+		this.jiraBoardAsTeam = jiraBoardAsTeam;
 	}
 }

--- a/core/src/main/java/com/capitalone/dashboard/model/Team.java
+++ b/core/src/main/java/com/capitalone/dashboard/model/Team.java
@@ -19,6 +19,7 @@ public class Team extends BaseModel {
     private String assetState;
     private String isDeleted;
     private boolean enabled;
+    private String teamType;
 
     @Transient
     private Collector collector;
@@ -90,6 +91,14 @@ public class Team extends BaseModel {
 
     public void setEnabled(boolean enabled) {
         this.enabled = enabled;
+    }
+
+    public String getTeamType() {
+        return teamType;
+    }
+
+    public void setTeamType(String teamType) {
+        this.teamType = teamType;
     }
 
     /* (non-Javadoc)

--- a/core/src/main/java/com/capitalone/dashboard/repository/TeamRepository.java
+++ b/core/src/main/java/com/capitalone/dashboard/repository/TeamRepository.java
@@ -18,6 +18,8 @@ public interface TeamRepository extends CrudRepository<Team, ObjectId>,
 
     Team findByTeamId(String teamId);
 
+    Team findByName(String name);
+
     /**
      * This essentially returns the max change date from the collection, based
      * on the last change date (or default delta change date property) available


### PR DESCRIPTION
* Update readme for encryption section.

* Change load order of AWSCredentialsProviderChain.

* Active directory support and administer dashboard owners.

* Active directory support and administer dashboard owners.

* Secure APIs Basic Auth.

* Secure APIs Basic Auth.

* Secure APIs Basic Auth.

* Secure APIs Basic Auth.

* Secure APIs Basic Auth.

* Fix for api losing connectivity with mongo.

* Fix AuthType stacktrace.

* Cleanup files and fix token auth type.

* Fix for github pulls, issues and commits.

* Fix for github pulls, issues and commits.

* Fix for null authType.

* Add functionality to validate user for remote dashboard creation api.

* Add functionality to validate user for remote dashboard creation api.

* Fix for ldap search user for remote dashboard creation.

* Fix for ldap search user for remote dashboard creation.

* Fix for ldap search user for remote dashboard creation.

* Fix for ldap search user for remote dashboard creation.

* Fix for ldap search user for remote dashboard creation.

* Set skipDockerBuild to true.

* Fix apiaudit target, uib-typeahead for quality widget, Null ptr exceptions for jenkins job config history.

* Fix apiaudit swagger.

* Add jenkins job config history types.

* Add support for Jira feature widget to display boards as teams.