### PR TITLE
Add indexes on commits and test_results collections (#1781)

### DIFF
--- a/core/src/main/java/com/capitalone/dashboard/model/Commit.java
+++ b/core/src/main/java/com/capitalone/dashboard/model/Commit.java
@@ -2,6 +2,8 @@ package com.capitalone.dashboard.model;
 
 import org.bson.types.ObjectId;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
+import org.springframework.data.mongodb.core.index.CompoundIndexes;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 /**
@@ -17,6 +19,9 @@ import org.springframework.data.mongodb.core.mapping.Document;
  *
  */
 @Document(collection="commits")
+@CompoundIndexes({
+        @CompoundIndex(name = "sha_url", def = "{'scmRevisionNumber' : 1, 'scmUrl': 1}")
+})
 public class Commit extends SCM {
     @Id
     private ObjectId id;

--- a/core/src/main/java/com/capitalone/dashboard/model/TestResult.java
+++ b/core/src/main/java/com/capitalone/dashboard/model/TestResult.java
@@ -1,6 +1,8 @@
 package com.capitalone.dashboard.model;
 
 import org.bson.types.ObjectId;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
+import org.springframework.data.mongodb.core.index.CompoundIndexes;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.util.ArrayList;
@@ -18,6 +20,9 @@ import java.util.Collection;
  *
  */
 @Document(collection="test_results")
+@CompoundIndexes({
+        @CompoundIndex(name = "test_results_collItemId_ts_idx", def = "{'collectorItemId' : 1, 'timestamp': -1}")
+})
 public class TestResult extends BaseModel {
     /**
      * ID of {@link CollectorItem}


### PR DESCRIPTION
* Fix for null team.

* Fix for jira projects and teams with trailing spaces.

* Update docker properties for jira collector.

* Auditapi handle commits not part of pull request.

* Auditapi flag first repo commit separately.

* Auditapi add branching strategy status.

* Handle case where fork could be deleted.

* Add statuses for dashboard not registered and no pull reqs for a date range.

* Add ability to make authenticated calls using github personal access token.

* Apiaudit support for multiple repos per dashboard.

* Add fix for PRs merged before commits were collected on that repo.

* Add fix for PRs merged before commits were collected on that repo.

* Handle case where comments url pages are not found.

* Handle case where comments url pages are not found.

* Handle case where comments url pages are not found.

* Exclude service unavailable from error threshold.

* Handle repo server outages.

* Add indexes on commit and test_results collections.